### PR TITLE
Removes hard coded install_dir and fixes default perms.

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -35,24 +35,24 @@ scope :group => :unit
 
 group :unit do
   guard :rubocop do
-    watch(/.+\.rb$/)
-    watch(/(?:.+\/)?\.rubocop\.yml$/) { |m| File.dirname(m[0]) }
+    watch(%r{/.+\.rb$/})
+    watch(%r{/(?:.+\/)?\.rubocop\.yml$/}) { |m| File.dirname(m[0]) }
   end
 
   guard :foodcritic, :cli => '--epic-fail any --tags ~FC007 --tags ~FC015 --tags ~FC023', :cookbook_paths => '.', :all_on_start => false do
-    watch(/attributes\/.+\.rb$/)
-    watch(/providers\/.+\.rb$/)
-    watch(/recipes\/.+\.rb$/)
-    watch(/resources\/.+\.rb$/)
-    watch(/definitions\/.+\.rb$/)
+    watch(%r{/attributes\/.+\.rb$/})
+    watch(%r{/providers\/.+\.rb$/})
+    watch(%r{/recipes\/.+\.rb$/})
+    watch(%r{/resources\/.+\.rb$/})
+    watch(%r{/definitions\/.+\.rb$/})
   end
 
   guard :rspec, :cmd => 'chef exec rspec --fail-fast', :all_on_start => false do
-    watch(/{^libraries\/(.+)\.rb$/)
-    watch(/^spec\/(.+)_spec\.rb$/)
-    watch(/^(recipes)\/(.+)\.rb$/)   { |m| "spec/#{m[1]}_spec.rb" }
-    watch(/^recipes\/common\.rb$/)   { 'spec' }
+    watch(%r{/{^libraries\/(.+)\.rb$/})
+    watch(%r{/^spec\/(.+)_spec\.rb$/})
+    watch(%r{/^(recipes)\/(.+)\.rb$/})   { |m| "spec/#{m[1]}_spec.rb" }
+    watch(%r{/^recipes\/common\.rb$/})   { 'spec' }
     watch('spec/spec_helper.rb')      { 'spec' }
-    watch(/^(.+)erb$/) { 'spec' }
+    watch(%r{/^(.+)erb$/}) { 'spec' }
   end
 end

--- a/Guardfile
+++ b/Guardfile
@@ -48,7 +48,7 @@ group :unit do
   end
 
   guard :rspec, :cmd => 'chef exec rspec --fail-fast', :all_on_start => false do
-    watch(%r{/{^libraries\/(.+)\.rb$/})
+    watch(%r{/^libraries\/(.+)\.rb$/})
     watch(%r{/^spec\/(.+)_spec\.rb$/})
     watch(%r{/^(recipes)\/(.+)\.rb$/})   { |m| "spec/#{m[1]}_spec.rb" }
     watch(%r{/^recipes\/common\.rb$/})   { 'spec' }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'lewuathe@me.com'
 license 'MIT License'
 description 'Installs/Configures storm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.17'
+version '0.0.18'
 depends 'java'
 source_url 'https://github.com/Lewuathe/storm-cookbook'
 issues_url 'https://github.com/Lewuathe/storm-cookbook/issues'

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -31,10 +31,10 @@ user 'storm' do
   action :create
 end
 
-directory '/usr/share/storm' do
+directory node['storm']['install_dir'] do
   owner 'root'
   group 'root'
-  mode '0644'
+  mode '0755'
   action :create
 end
 

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -16,14 +16,14 @@ describe 'storm-cluster::common' do
       expect(chef_run).to create_cookbook_file(
         '/tmp/config_hosts.sh').with(
           source: 'config_hosts.sh'
-      )
+          )
     end
 
     it 'runs the config_hosts.sh script' do
       expect(chef_run).to run_script('config_hosts').with(
         interpreter: 'bash',
         user:        'root'
-      )
+        )
     end
 
     it 'adds the storm user to run the storm application as' do
@@ -32,7 +32,7 @@ describe 'storm-cluster::common' do
         group:     'storm',
         home:    '/home/storm',
         shell:   '/bin/bash'
-     )
+        )
     end
 
     it "creates the directory #{node['storm']['install_dir']}" do
@@ -40,14 +40,14 @@ describe 'storm-cluster::common' do
         owner: 'root',
         group: 'root',
         mode:  '0644'
-      )
+        )
     end
 
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do
       expect(chef_run).to create_cookbook_file(
         '/tmp/apache-storm-0.9.3.tar.gz').with(
           source: 'apache-storm-0.9.3.tar.gz'
-      )
+        )
     end
 
     it 'runs the install script' do

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -15,15 +15,13 @@ describe 'storm-cluster::common' do
     it 'creates the file "/tmp/config_hosts.sh"' do
       expect(chef_run).to create_cookbook_file(
         '/tmp/config_hosts.sh').with(
-          source: 'config_hosts.sh'
-          )
+          source: 'config_hosts.sh')
     end
 
     it 'runs the config_hosts.sh script' do
       expect(chef_run).to run_script('config_hosts').with(
         interpreter: 'bash',
-        user:        'root'
-        )
+        user:        'root')
     end
 
     it 'adds the storm user to run the storm application as' do
@@ -31,30 +29,26 @@ describe 'storm-cluster::common' do
         comment: 'For storm services',
         group:     'storm',
         home:    '/home/storm',
-        shell:   '/bin/bash'
-        )
+        shell:   '/bin/bash')
     end
 
     it "creates the directory #{node['storm']['install_dir']}" do
       expect(chef_run).to create_directory(node['storm']['install_dir']).with(
         owner: 'root',
         group: 'root',
-        mode:  '0644'
-        )
+        mode:  '0644')
     end
 
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do
       expect(chef_run).to create_cookbook_file(
         '/tmp/apache-storm-0.9.3.tar.gz').with(
-          source: 'apache-storm-0.9.3.tar.gz'
-        )
+          source: 'apache-storm-0.9.3.tar.gz')
     end
 
     it 'runs the install script' do
       expect(chef_run).to run_script('install_storm').with(
         interpreter: 'bash',
-        user:        'root'
-      )
+        user:        'root')
     end
 
     it 'adds the tempalted file /usr/share/storm/apache-storm-0.9.3/conf/storm.yaml' do
@@ -63,8 +57,7 @@ describe 'storm-cluster::common' do
           source: 'storm.yaml.erb',
           mode:   '0440',
           owner:  'root',
-          group:  'root'
-      )
+          group:  'root')
     end
 
     it 'renders the template storm.yaml tempalte with contents from ./spec/rendered_templates/storm.yaml' do
@@ -82,8 +75,7 @@ describe 'storm-cluster::common' do
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do
       expect(chef_run).to create_remote_file(
         '/tmp/apache-storm-0.9.3.tar.gz').with(
-          source: 'http://mirror.sdunix.com/apache/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz'
-      )
+          source: 'http://mirror.sdunix.com/apache/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz')
     end
   end
 end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -32,11 +32,11 @@ describe 'storm-cluster::common' do
         shell:   '/bin/bash')
     end
 
-    it "creates the directory #{node['storm']['install_dir']}" do
-      expect(chef_run).to create_directory(node['storm']['install_dir']).with(
+    it 'creates the directory /usr/share/storm'  do
+      expect(chef_run).to create_directory('/usr/share/storm').with(
         owner: 'root',
         group: 'root',
-        mode:  '0644')
+        mode:  '0755')
     end
 
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -35,8 +35,8 @@ describe 'storm-cluster::common' do
      )
     end
 
-    it 'creates the directory /usr/share/storm' do
-      expect(chef_run).to create_directory('/usr/share/storm').with(
+    it "creates the directory #{node['storm']['install_dir']}" do
+      expect(chef_run).to create_directory(node['storm']['install_dir']).with(
         owner: 'root',
         group: 'root',
         mode:  '0644'


### PR DESCRIPTION
The current recipe for common.rb has a hard-coded directory creation: /usr/share/storm. It also uses incorrect default permissions '0644' which is rw-r-r, this directory need execute permissions: '0755'. I added the attribute node['storm']['install_dir'] instead of '/usr/share/storm' so it behaves as expected. 
