### PR TITLE
storm.yaml has empty string zookeeper entry

### DIFF
--- a/attributes/storm_yaml.rb
+++ b/attributes/storm_yaml.rb
@@ -1,6 +1,6 @@
 ########### These MUST be filled in for a storm configuration
 default['storm']['storm_yaml']['nimbus.host'] = ''
-default['storm']['storm_yaml']['storm.zookeeper.servers'] = ['']
+default['storm']['storm_yaml']['storm.zookeeper.servers'] = []
 #
 #
 # ##### These may optionally be filled in:


### PR DESCRIPTION
Chef merges attributes hashes from each attribute precedence instead of overwriting them.

Blank entry in the zookeeper server hash causes a blank entry to be added to the storm.yaml config.  The hash itself should be empty without an empty string.
