### PR TITLE
Remove redundant sudo call

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -15,7 +15,7 @@ script 'config_hosts' do
   interpreter 'bash'
   user 'root'
   code <<-EOL
-     sudo ./tmp/config_hosts.sh
+     ./tmp/config_hosts.sh
   EOL
 end
 


### PR DESCRIPTION
Everything is already running as root, so calling sudo does not accomplish anything.

Having sudo in the mix can, however, cause gratuitous issues with problematic sudo configurations.

I realize the sudo call was only recently added to fix a "permission denied", but it's not clear to me how that could happen.
