### PR TITLE
Allow metadata.rb to work with Chef 11

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -52,7 +52,7 @@ group :unit do
     watch(%r{/^spec\/(.+)_spec\.rb$/})
     watch(%r{/^(recipes)\/(.+)\.rb$/})   { |m| "spec/#{m[1]}_spec.rb" }
     watch(%r{/^recipes\/common\.rb$/})   { 'spec' }
-    watch('spec/spec_helper.rb')      { 'spec' }
+    watch('spec/spec_helper.rb') { 'spec' }
     watch(%r{/^(.+)erb$/}) { 'spec' }
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,12 @@ description 'Installs/Configures storm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.19'
 depends 'java'
-source_url 'https://github.com/Lewuathe/storm-cookbook'
-issues_url 'https://github.com/Lewuathe/storm-cookbook/issues'
+begin
+  source_url 'https://github.com/Lewuathe/storm-cookbook'
+  issues_url 'https://github.com/Lewuathe/storm-cookbook/issues'
+rescue NoMethodError
+  nil
+end
 provides 'storm-cluster::nimbus'
 provides 'storm-cluster::supervisor'
 supports 'ubuntu'

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -27,12 +27,12 @@ describe 'storm-cluster::common' do
     it 'adds the storm user to run the storm application as' do
       expect(chef_run).to create_user('storm').with(
         comment: 'For storm services',
-        group:     'storm',
+        group:   'storm',
         home:    '/home/storm',
         shell:   '/bin/bash')
     end
 
-    it 'creates the directory /usr/share/storm'  do
+    it 'creates the directory /usr/share/storm' do
       expect(chef_run).to create_directory('/usr/share/storm').with(
         owner: 'root',
         group: 'root',


### PR DESCRIPTION
Chef 11 doesn't support the `source_url` and `issues_url` methods currently used in the metadata file. This change wraps them in a conditional to allow compatibility with Chef 11.

I tested this against Chef 11 and 12 on Ubuntu 12.04 using Vagrant as well as Ubuntu 12.04 on OpsWorks.

Update: Not really sure why Rubocop was complaining on Travis (ran fine locally...) but that's the reason for the unrelated whitespace changes.
