### PR TITLE
Use Upstart for all Ubuntu versions

### DIFF
--- a/recipes/nimbus.rb
+++ b/recipes/nimbus.rb
@@ -22,17 +22,13 @@ end
 
 service 'storm-nimbus' do
   supports :status => true, :restart => true
-  if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
-    then provider Chef::Provider::Service::Upstart
-  end
+  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
 end
 
 service 'storm-ui' do
   supports :status => true, :restart => true
-  if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
-    then provider Chef::Provider::Service::Upstart
-  end
+  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
 end
 

--- a/recipes/supervisor.rb
+++ b/recipes/supervisor.rb
@@ -12,9 +12,7 @@ end
 
 service 'storm-supervisor' do
   supports :status => true, :restart => true
-  if node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
-    then provider Chef::Provider::Service::Upstart
-  end
+  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
 end
 


### PR DESCRIPTION
The `nimbus` and `supervisor` recipes already use `Upstart` so this change simply removes the `platform_version` check so it will work with more versions of Ubuntu. `Upstart` was first included in Ubuntu `6` so I think this is a reasonable assumption.

Tested this locally against Ubuntu `12.04` and `14.04` with success.

Failing with the same problems as #9. I'll avoid repeating them in hopes that that is merged :smile: 
