### PR TITLE
Run daemons as configurable user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default['storm']['version'] = '0.9.3'
 default['storm']['package'] = "apache-storm-#{node['storm']['version']}"
 default['storm']['install_dir'] = '/usr/share/storm'
+default['storm']['user'] = 'storm'
 
 default['storm']['install_method'] = 'cookbook_file'
 

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -1,5 +1,6 @@
 include_recipe 'java'
 
+storm_user = node['storm']['user']
 storm_package_name = node['storm']['package']
 storm_version = node['storm']['version']
 storm_remote_name = "#{node['storm']['download_url']}#{node['storm']['download_dir']}"
@@ -19,14 +20,14 @@ script 'config_hosts' do
   EOL
 end
 
-group 'storm' do
+group storm_user do
   action :create
 end
 
-user 'storm' do
+user storm_user do
   comment 'For storm services'
-  gid 'storm'
-  home '/home/storm'
+  gid storm_user
+  home "/home/#{storm_user}"
   shell '/bin/bash'
   action :create
 end
@@ -56,16 +57,16 @@ script 'install_storm' do
     tar zxvf /tmp/#{storm_package_name}.tar.gz -C #{install_dir}
     rm -rf #{install_dir}/#{storm_version}
     mv #{install_dir}/#{storm_package_name} #{install_dir}/#{storm_version}
-    chown -R storm:storm #{install_dir}/#{storm_version}
+    chown -R #{storm_user}:#{storm_user} #{install_dir}/#{storm_version}
   EOL
   not_if { ::File.exist?("#{install_dir}/#{storm_version}") }
 end
 
 template "#{install_dir}/#{storm_version}/conf/storm.yaml" do
   source 'storm.yaml.erb'
-  mode '0440'
-  owner 'root'
-  group 'root'
+  mode '0644'
+  owner storm_user
+  group storm_user
   variables(
     'storm_yaml' => node['storm']['storm_yaml']
   )

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -55,9 +55,9 @@ describe 'storm-cluster::common' do
       expect(chef_run).to create_template(
         '/usr/share/storm/0.9.3/conf/storm.yaml').with(
           source: 'storm.yaml.erb',
-          mode:   '0440',
-          owner:  'root',
-          group:  'root')
+          mode:   '0644',
+          owner:  'storm',
+          group:  'storm')
     end
 
     it 'renders the template storm.yaml tempalte with contents from ./spec/rendered_templates/storm.yaml' do

--- a/spec/rendered_templates/storm-drpc.conf
+++ b/spec/rendered_templates/storm-drpc.conf
@@ -4,6 +4,9 @@ author  "Kai Sasaki <lewuathe@me.com>"
 start on runlevel [2345]
 stop on runlevel [016]
 
+setuid storm
+setgid storm
+
 chdir /usr/share/storm/0.9.3
 exec bin/storm drpc 2>&1
 respawn

--- a/spec/rendered_templates/storm-nimbus.conf
+++ b/spec/rendered_templates/storm-nimbus.conf
@@ -4,6 +4,9 @@ author  "Kai Sasaki <lewuathe@me.com>"
 start on runlevel [2345]
 stop on runlevel [016]
 
+setuid storm
+setgid storm
+
 chdir /usr/share/storm/0.9.3
 exec bin/storm nimbus 2>&1
 respawn

--- a/spec/rendered_templates/storm-supervisor.conf
+++ b/spec/rendered_templates/storm-supervisor.conf
@@ -4,6 +4,9 @@ author  "Kai Sasaki <lewuathe@me.com>"
 start on runlevel [2345]
 stop on runlevel [016]
 
+setuid storm
+setgid storm
+
 chdir /usr/share/storm/0.9.3
 exec bin/storm supervisor 2>&1
 respawn

--- a/spec/rendered_templates/storm-ui.conf
+++ b/spec/rendered_templates/storm-ui.conf
@@ -4,6 +4,9 @@ author  "Kai Sasaki <lewuathe@me.com>"
 start on runlevel [2345]
 stop on runlevel [016]
 
+setuid storm
+setgid storm
+
 chdir /usr/share/storm/0.9.3
 exec bin/storm ui 2>&1
 respawn

--- a/templates/default/storm-daemon.conf.erb
+++ b/templates/default/storm-daemon.conf.erb
@@ -4,6 +4,9 @@ author  "Kai Sasaki <lewuathe@me.com>"
 start on runlevel [2345]
 stop on runlevel [016]
 
+setuid <%= node['storm']['user'] %>
+setgid <%= node['storm']['user'] %>
+
 chdir <%= node['storm']['install_dir'] %>/<%= node['storm']['version'] %>
 exec bin/storm <%= @service %> 2>&1
 respawn


### PR DESCRIPTION
This changes allows users to customize the name of the Storm user as well as run the daemons under this user. I also changed the permissions of `storm.yaml` to `0644` so that it's editable via a `sudo vim /usr/share/storm/0.9.3/conf/storm.yaml` rather than having to manually flip the writable bit.

Let me know if you have concerns with any of this.

Tested on Ubuntu 12.04 and 14.04 locally using Vagrant.
