### PR TITLE
Ensure YAML is generated correctly by converting to JSON and back

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 include_recipe 'java'
 
 storm_package_name = node['storm']['package']
@@ -67,6 +69,6 @@ template "#{install_dir}/#{storm_version}/conf/storm.yaml" do
   owner 'root'
   group 'root'
   variables(
-    'storm_yaml' => node['storm']['storm_yaml']
+    'storm_yaml' => JSON.parse(node['storm']['storm_yaml'].to_hash.dup.to_json)
   )
 end


### PR DESCRIPTION
In my testing I was getting the following out in `storm.yaml`:

```
  nimbus.host: ''
  storm.zookeeper.servers: !ruby/array:Chef::Node::ImmutableArray
  - foo
  - bar
```

By converting the `storm_yaml` hash to JSON and back the correct YAML is generated:

```
  nimbus.host: ''
  storm.zookeeper.servers:
  - foo
  - bar
```

Tested on Ubuntu 12.04 and 14.04 locally using Vagrant.
