### PR TITLE
Container base test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: ruby
 cache: bundler
+sudo: false
 rvm:
   - 2.0.0
   - 2.0.0-p576
 
 env:
   - CHEF_VERSION=12.0.3
-
-install:
-  - sudo apt-get update -q
-  - sudo apt-get install -q virtualbox --fix-missing
-  - sudo wget -nv https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
-  - sudo dpkg -i vagrant_1.7.2_x86_64.deb
-  - bundle install
 
 script:
   - bundle exec rake travis

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,3 @@ group :test do
   gem 'guard-rubocop'
   gem 'guard-foodcritic'
 end
-
-group :integration do
-  gem 'test-kitchen'
-  gem 'kitchen-vagrant'
-end


### PR DESCRIPTION
Migration to container-based infrastructure of Travis. (#14) The process is written [here](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).
