### PR TITLE
[#18] Update apt-get cache before installing jdk

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,14 +3,13 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.4
 
 suites:
-  - name: default
+  - name: storm-nimbus
     run_list:
-      - recipe[storm-cluster::default]
+      - recipe[storm-cluster::nimbus]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,6 @@
 source 'https://supermarket.getchef.com'
 
 metadata
+
+cookbook 'java', '~> 1.35.0'
+cookbook 'apt', '= 2.3.8'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['storm']['package'] = "apache-storm-#{node['storm']['version']}"
 default['storm']['install_dir'] = '/usr/share/storm'
 default['storm']['user'] = 'storm'
 
-default['storm']['install_method'] = 'cookbook_file'
+default['storm']['install_method'] = 'remote_file'
 
 default['storm']['download_url'] = 'http://mirror.sdunix.com/apache/storm'
 default['storm']['download_dir'] = "/apache-storm-#{node['storm']['version']}/apache-storm-#{node['storm']['version']}.tar.gz"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['storm']['package'] = "apache-storm-#{node['storm']['version']}"
 default['storm']['install_dir'] = '/usr/share/storm'
 default['storm']['user'] = 'storm'
 
-default['storm']['install_method'] = 'remote_file'
+default['storm']['install_method'] = 'cookbook_file'
 
 default['storm']['download_url'] = 'http://mirror.sdunix.com/apache/storm'
 default['storm']['download_dir'] = "/apache-storm-#{node['storm']['version']}/apache-storm-#{node['storm']['version']}.tar.gz"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ description 'Installs/Configures storm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.21'
 depends 'java'
+depends 'apt'
 begin
   source_url 'https://github.com/Lewuathe/storm-cookbook'
   issues_url 'https://github.com/Lewuathe/storm-cookbook/issues'

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -1,5 +1,6 @@
 require 'json'
 
+include_recipe 'apt'
 include_recipe 'java'
 
 storm_user = node['storm']['user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,11 @@
 # Cookbook Name:: storm
 # Recipe:: default
 #
-# Copyright 2015, YOUR_COMPANY_NAME
+# Copyright 2015, Kai Sasaki
 #
 # All rights reserved - Do Not Redistribute
 #
+
+include_recipe 'storm-cluster::common'
+
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,5 +8,3 @@
 #
 
 include_recipe 'storm-cluster::common'
-
-


### PR DESCRIPTION
In order to install OpenJDK on Ubuntu, it is necessary to update apt-get cache.
This task can be delegates to [apt](https://supermarket.chef.io/cookbooks/apt/versions/2.3.8). This fix #18 issue.
