### PR TITLE
Optionally add storm UI 'log viewer' service through new attribute

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ LineLength:
   Enabled: false
 MethodLength:
   Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
 SignalException:
   Enabled: false
 TrailingCommaInLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,9 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
+  Enabled: false
+TrailingCommaInArguments:
   Enabled: false
 WordArray:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.0.0-p576
+  - 2.2.0
 
 env:
   - CHEF_VERSION=12.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2.0
+  - 2.2.2
 
 env:
   - CHEF_VERSION=12.0.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ gem 'berkshelf'
 gem 'rake'
 
 group :test do
-  gem 'foodcritic'
-  gem 'rubocop'
   gem 'chefspec'
+  gem 'foodcritic'
   gem 'guard'
+  gem 'guard-foodcritic'
   gem 'guard-rspec'
   gem 'guard-rubocop'
-  gem 'guard-foodcritic'
+  gem 'rubocop'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,5 @@ default['storm']['install_method'] = 'cookbook_file'
 
 default['storm']['download_url'] = 'http://mirror.sdunix.com/apache/storm'
 default['storm']['download_dir'] = "/apache-storm-#{node['storm']['version']}/apache-storm-#{node['storm']['version']}.tar.gz"
+
+default['storm']['enable_logviewer'] = 'false'

--- a/recipes/supervisor.rb
+++ b/recipes/supervisor.rb
@@ -1,6 +1,6 @@
 include_recipe 'storm-cluster::common'
 
-# Optionally enable the log viewer service on worker nodes
+# Optionally enable the log viewer service on worker/supervisor nodes
 
 template '/etc/init/storm-logviewer.conf' do
   source 'storm-daemon.conf.erb'
@@ -10,12 +10,14 @@ template '/etc/init/storm-logviewer.conf' do
   variables(
     :service => 'logviewer'
   )
+  only_if node['storm']['enable_logviewer']
 end
 
 service 'storm-logviewer' do
   supports :status => true, :restart => true
   provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
+  only_if node['storm']['enable_logviewer']
 end
 
 template '/etc/init/storm-supervisor.conf' do
@@ -26,14 +28,12 @@ template '/etc/init/storm-supervisor.conf' do
   variables(
     :service => 'supervisor'
   )
-  only_if node['storm']['enable_logviewer']
 end
 
 service 'storm-supervisor' do
   supports :status => true, :restart => true
   provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
-  only_if node['storm']['enable_logviewer']
 end
 
 # script 'start_nimbus' do

--- a/recipes/supervisor.rb
+++ b/recipes/supervisor.rb
@@ -10,14 +10,14 @@ template '/etc/init/storm-logviewer.conf' do
   variables(
     :service => 'logviewer'
   )
-  only_if node['storm']['enable_logviewer']
+  only_if node['storm']['enable_logviewer'] == 'true'
 end
 
 service 'storm-logviewer' do
   supports :status => true, :restart => true
   provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
-  only_if node['storm']['enable_logviewer']
+  only_if node['storm']['enable_logviewer'] == 'true'
 end
 
 template '/etc/init/storm-supervisor.conf' do

--- a/recipes/supervisor.rb
+++ b/recipes/supervisor.rb
@@ -1,5 +1,23 @@
 include_recipe 'storm-cluster::common'
 
+# Optionally enable the log viewer service on worker nodes
+
+template '/etc/init/storm-logviewer.conf' do
+  source 'storm-daemon.conf.erb'
+  mode '0644'
+  owner 'root'
+  group 'root'
+  variables(
+    :service => 'logviewer'
+  )
+end
+
+service 'storm-logviewer' do
+  supports :status => true, :restart => true
+  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
+  action :start
+end
+
 template '/etc/init/storm-supervisor.conf' do
   source 'storm-daemon.conf.erb'
   mode '0644'
@@ -8,12 +26,14 @@ template '/etc/init/storm-supervisor.conf' do
   variables(
     :service => 'supervisor'
   )
+  only_if node['storm']['enable_logviewer']
 end
 
 service 'storm-supervisor' do
   supports :status => true, :restart => true
   provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
   action :start
+  only_if node['storm']['enable_logviewer']
 end
 
 # script 'start_nimbus' do

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -14,14 +14,17 @@ describe 'storm-cluster::common' do
 
     it 'creates the file "/tmp/config_hosts.sh"' do
       expect(chef_run).to create_cookbook_file(
-        '/tmp/config_hosts.sh').with(
-          source: 'config_hosts.sh')
+        '/tmp/config_hosts.sh'
+      ).with(
+        source: 'config_hosts.sh'
+      )
     end
 
     it 'runs the config_hosts.sh script' do
       expect(chef_run).to run_script('config_hosts').with(
         interpreter: 'bash',
-        user:        'root')
+        user:        'root'
+      )
     end
 
     it 'adds the storm user to run the storm application as' do
@@ -29,35 +32,42 @@ describe 'storm-cluster::common' do
         comment: 'For storm services',
         group:   'storm',
         home:    '/home/storm',
-        shell:   '/bin/bash')
+        shell:   '/bin/bash'
+      )
     end
 
     it 'creates the directory /usr/share/storm' do
       expect(chef_run).to create_directory('/usr/share/storm').with(
         owner: 'root',
         group: 'root',
-        mode:  '0755')
+        mode:  '0755'
+      )
     end
 
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do
       expect(chef_run).to create_cookbook_file(
-        '/tmp/apache-storm-0.9.3.tar.gz').with(
-          source: 'apache-storm-0.9.3.tar.gz')
+        '/tmp/apache-storm-0.9.3.tar.gz'
+      ).with(
+        source: 'apache-storm-0.9.3.tar.gz'
+      )
     end
 
     it 'runs the install script' do
       expect(chef_run).to run_script('install_storm').with(
         interpreter: 'bash',
-        user:        'root')
+        user:        'root'
+      )
     end
 
     it 'adds the tempalted file /usr/share/storm/apache-storm-0.9.3/conf/storm.yaml' do
       expect(chef_run).to create_template(
-        '/usr/share/storm/0.9.3/conf/storm.yaml').with(
-          source: 'storm.yaml.erb',
-          mode:   '0644',
-          owner:  'storm',
-          group:  'storm')
+        '/usr/share/storm/0.9.3/conf/storm.yaml'
+      ).with(
+        source: 'storm.yaml.erb',
+        mode:   '0644',
+        owner:  'storm',
+        group:  'storm'
+      )
     end
 
     it 'renders the template storm.yaml tempalte with contents from ./spec/rendered_templates/storm.yaml' do
@@ -74,8 +84,10 @@ describe 'storm-cluster::common' do
 
     it 'creates the file "/tmp/apache-storm-0.9.3.tar.gz"' do
       expect(chef_run).to create_remote_file(
-        '/tmp/apache-storm-0.9.3.tar.gz').with(
-          source: 'http://mirror.sdunix.com/apache/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz')
+        '/tmp/apache-storm-0.9.3.tar.gz'
+      ).with(
+        source: 'http://mirror.sdunix.com/apache/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz'
+      )
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '14.04'
+end
+
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'storm-cluster::supervisor' do
-  let(:chef_run) do 
+  let(:chef_run) do
     ChefSpec::ServerRunner.new do |node|
       node.override['storm']['enable_logviewer'] = true
     end.converge(described_recipe)

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe 'storm-cluster::supervisor' do
-  cached(:chef_run) { ChefSpec::ServerRunner.converge(described_recipe) }
+  let(:chef_run) do 
+    ChefSpec::ServerRunner.new do |node|
+      node.override['storm']['enable_logviewer'] = true
+    end.converge(described_recipe)
+  end
 
   it 'Includes the common recipe' do
     expect(chef_run).to include_recipe('storm-cluster::common')
@@ -19,6 +23,15 @@ describe 'storm-cluster::supervisor' do
   it 'renders the file /etc/init/storm-supervisor.conf with content from ./spec/rendered_templates/storm-supervisor.conf' do
     storm_supervisor_conf = File.read('./spec/rendered_templates/storm-supervisor.conf')
     expect(chef_run).to render_file('/etc/init/storm-supervisor.conf').with_content(storm_supervisor_conf)
+  end
+
+  it 'creates adds the templated file "/etc/init/storm-logviewer.conf"' do
+    expect(chef_run).to create_template('/etc/init/storm-logviewer.conf').with(
+      source: 'storm-daemon.conf.erb',
+      mode:   '0644',
+      owner:  'root',
+      group:  'root'
+    )
   end
 
   it 'starts the storm-supervisor service' do


### PR DESCRIPTION
Default behavior should be unchanged with this change.

Users can optionally change default['storm']['enable_logviewer'] = 'false'  to 'true' which will enable the web link functionality to view log files for worker/supervisor nodes.